### PR TITLE
save non numeric sequence ids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 before_script: npm install -g npm@latest
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
   - 'iojs'

--- a/seq-file.js
+++ b/seq-file.js
@@ -35,11 +35,14 @@ SeqFile.prototype.readSync = function() {
 }
 
 SeqFile.prototype.save = function(n) {
+  var skip
   if (n && n > this.seq)
     this.seq = n
 
-   // only save occasionally to cut down on I/O.
-  if ((n || 0) % this.frequency !== 0) return
+  skip = (n || 0) % this.frequency
+
+  // only save occasionally to cut down on I/O.
+  if (!isNaN(skip) && skip !== 0) return
 
   if (!this.saving) {
     this.saving = true

--- a/seq-file.js
+++ b/seq-file.js
@@ -65,6 +65,7 @@ SeqFile.prototype.onFinish = function() {
 }
 
 SeqFile.prototype.onRead = function(cb, er, data) {
+
   if (er && er.code === 'ENOENT')
     data = 0;
   else if (er) {
@@ -75,13 +76,21 @@ SeqFile.prototype.onRead = function(cb, er, data) {
   }
 
   if (data === undefined)
-    data = null
+    data = 0
 
-  if (!+data && +data !== 0)
-    return cb(new Error('invalid data in seqFile'))
+  if (data.length > 1) {
+    // remove delimiter
+    data = (data + '').trim()
+    if (/^\d+$/.test(data)) 
+      data = + data
+    else
+      // compare strings
+      this.seq = this.seq + ''
+  } else {
+    data = 0
+  }
 
-  data = +data
-  if (!er && data > this.seq)
+  if (data > this.seq) 
     this.seq = data
 
   if (cb)

--- a/test/03-save-non-number.js
+++ b/test/03-save-non-number.js
@@ -1,0 +1,16 @@
+var test = require('tap').test
+
+var SeqFile = require('../seq-file.js')
+
+var fs = require('fs')
+var sf = __dirname + '/test.seq'
+
+test('saves non number sequence ids', function(t) {
+  var s = new SeqFile(sf)
+  s.seq = '1-1110'
+  s.save('1-1111')
+  setTimeout(function(){
+    t.equal(fs.readFileSync(sf, 'ascii'), '1-1111\n')
+    t.end()
+  },50)
+})

--- a/test/04-read-non-number.js
+++ b/test/04-read-non-number.js
@@ -1,0 +1,15 @@
+var test = require('tap').test
+
+var SeqFile = require('../seq-file.js')
+
+var fs = require('fs')
+var sf = __dirname + '/test.seq'
+
+test('reads non number sequence ids froim file', function(t) {
+  var s = new SeqFile(sf)
+  s.read(function(err,data){
+    t.equal(data, '1-1111')
+    t.equal(s.seq, '1-1111')
+    t.end()
+  })
+})


### PR DESCRIPTION
this allows users to save string values as a sequence ids. it's
assumed that the values provided will sort lexicographically as they
represent some sort of sequence.

prior to this non numeric sequence ids were skipped in the frequency
check. There was no api to know this was happening but we never told
anyone they could save things that were not numbers.

this may be a major bump because anyone who currently has a bug where
they pass a non numeric value as a sequence id will start saving that
value instead of ignoring it.