### PR TITLE
Update seq number format from numric to alpha-numeric

### DIFF
--- a/seq-file.js
+++ b/seq-file.js
@@ -13,6 +13,7 @@ function SeqFile(file, opts) {
   this.saving = false
   this.seq = 0
   this.frequency = opts.frequency || 1
+  this.delimiter = opts.delimiter || '-'
 }
 
 SeqFile.prototype.read = function(cb) {
@@ -34,10 +35,14 @@ SeqFile.prototype.readSync = function() {
   return this.onRead(null, er, data)
 }
 
+SeqFile.prototype.isSeqGreater = function(newSeq, oldSeq) {
+  return Number((newSeq + '').split(this.delimiter, 1)) > Number((oldSeq + '').split(this.delimiter, 1))
+}
+
 SeqFile.prototype.save = function(n) {
   var skip
   if (n){
-    if(n > this.seq)
+    if(this.isSeqGreater(n, this.seq))
       this.seq = n
     else if(this.seq === 0 && typeof n === 'string')
       this.seq = n


### PR DESCRIPTION
<!-- What / Why -->update seq check with new format `seq-alpha numeric`
<!-- Describe the request in detail. What it does and why it's being changed. -->
As we have observe there is change in seq Id from numeric to alpha-numeric(2-g1AAAACbeJzLYWBgYMpgTmEQTM4vTc5ISXIwNDLXMwBCwxyQVB4LkGRoAFL_gSArgzmRMRcowG5kbGmYap6ETR8e0xIZkupRjDE1NjKxSDTFpiELANXUJ_E)

when we are trying to save seq, it is not happening from "9999-g1AAAACbeJz" -> "120311-g1AAAACbeJz",   as we coming value directly previously

Now we need to split the first half i.e 99999 and 120311, then compare value for new format  

check this https://github.com/github/npm/issues/6983 for details on seq number 

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
https://github.com/github/npm/issues/6582