### PR TITLE
Add save sync method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "seq-file",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -71,9 +71,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
     "balanced-match": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,9 +2145,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
     "object-keys": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seq-file",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A module for storing the ever-increasing sequence files when following couchdb _changes feeds.",
   "main": "seq-file.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.2.8",
-    "standard": "^10.0.2",
+    "standard": "^10.0.3",
     "tap": "^1.2.0"
   },
   "scripts": {

--- a/seq-file.js
+++ b/seq-file.js
@@ -73,6 +73,23 @@ SeqFile.prototype.onFinish = function() {
   this.saving = false
 }
 
+SeqFile.prototype.saveSync = function(n) {
+  if (n){
+    this.seq = n
+  }
+  try {
+    this.saving = true
+    var t = this.file + '.TMP'
+    var data = this.seq + '\n'
+    fs.writeFileSync(t, data)
+    fs.renameSync(this.file + '.TMP', this.file)
+  } catch (e) {
+      console.log(e);
+      fs.unlinkSync(this.file + '.TMP')
+  }
+  this.saving = false
+}
+
 SeqFile.prototype.onRead = function(cb, er, data) {
 
   if (er && er.code === 'ENOENT')

--- a/seq-file.js
+++ b/seq-file.js
@@ -66,8 +66,8 @@ SeqFile.prototype.onFinish = function () {
   this.saving = false
 }
 
-SeqFile.prototype.saveSync = function(n) {
-  if (n){
+SeqFile.prototype.saveSync = function (n) {
+  if (n) {
     this.seq = n
   }
   try {
@@ -77,21 +77,15 @@ SeqFile.prototype.saveSync = function(n) {
     fs.writeFileSync(t, data)
     fs.renameSync(this.file + '.TMP', this.file)
   } catch (e) {
-      console.log(e);
-      fs.unlinkSync(this.file + '.TMP')
+    console.log(e)
+    fs.unlinkSync(this.file + '.TMP')
   }
   this.saving = false
 }
 
-SeqFile.prototype.onRead = function(cb, er, data) {
-
-  if (er && er.code === 'ENOENT')
-    data = 0;
-  else if (er) {
-    if (cb)
-      return cb(er)
-    else
-      throw er
+SeqFile.prototype.onRead = function (cb, er, data) {
+  if (er && er.code === 'ENOENT') { data = 0 } else if (er) {
+    if (cb) { return cb(er) } else { throw er }
   }
 
   if (data === undefined) { data = 0 }


### PR DESCRIPTION
**What / Why**
This PR adds a customised save sync method which is invoked when the pkg-info-cache receives a redis key event while switching the couch version to save to a specifc sequence. This will help when switching over to the couch 3.x version without the need to restart manually the registry-follower, hooks-follower services.

**References**
https://github.com/github/npm/issues/7045