### PR TITLE
Added missing required workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Ref: https://github.com/github/npm/issues/13757

Potential fix for [https://github.com/npm/personal/security/code-scanning/11](https://github.com/npm/personal/security/code-scanning/11)

To fix the problem, explicitly define a `permissions` block so the `GITHUB_TOKEN` is limited to the least privilege needed. This can be done at the workflow root (applies to all jobs) or at the job level for `publish`. Since there is only one job and it doesn’t require any write access to the repository, `contents: read` is sufficient and matches the CodeQL suggestion.

The best fix without changing functionality is to add a root-level `permissions` section immediately after the `name: Regular Publish` line. This will apply to the `publish` job and restrict the `GITHUB_TOKEN` to read-only repository contents. No existing steps need modification, and no additional actions or imports are required.

Concretely, in `.github/workflows/regular_publish.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Regular Publish`). This keeps the behavior identical while ensuring explicit least-privilege permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


Potential fix for [https://github.com/npm/seq-file/security/code-scanning/1](https://github.com/npm/seq-file/security/code-scanning/1)

In general, the problem is fixed by explicitly declaring a `permissions` block that restricts the default `GITHUB_TOKEN` scopes to the minimum required for the workflow. This can be defined at the top level of the workflow (affecting all jobs) or per job. For this CI workflow, none of the steps require write access to repository contents or other resources, so `contents: read` is sufficient and aligns with the CodeQL recommendation.

The best fix without changing existing functionality is to add a `permissions` section at the workflow root, just under `name: CI` (or at the `jobs.build` level). This way, all current and future jobs in this workflow will default to read-only access to repository contents via `GITHUB_TOKEN`. No other logic, steps, or secrets need to be changed; we’re only constraining the automatically provided token. Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

after the `name: CI` line. No imports or additional definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
